### PR TITLE
Use getFullYear

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ if (module.parent) {
 
 function days() {
   const date = new Date();
-  const year = date.getYear() + 1900;
+  const year = date.getFullYear();
   let xmas = moment([year, 11, 25]);
   const today = moment([year, date.getMonth(), date.getDate()]);
   const delta = xmas.diff(today, 'days');


### PR DESCRIPTION
`Date.prototype.getYear` has been deprecated for a very very long time, `getFullYear` is what should be used these days 😃 